### PR TITLE
Refactor to use React Context

### DIFF
--- a/src/Builder.js
+++ b/src/Builder.js
@@ -4,7 +4,14 @@ import { connect } from 'react-redux';
 import './css/App.css';
 import './css/db.css';
 import Map from './components/Map';
+import MapDistrictLayer from './components/MapDistrictLayer';
 import DistrictsSidebar from './components/DistrictsSidebar';
+import MapHighlightLayer from './components/MapHighlightLayer';
+import MapLockLayer from './components/MapLockLayer';
+import MapDrawHandler from './components/MapDrawHandler';
+import MapLayerHandler from './components/MapLayerHandler';
+import MapLabelHandler from './components/MapLabelHandler';
+import MapBasemapHandler from './components/MapBasemapHandler';
 import MapActions from './components/MapActions';
 import { generateAssignedDistricts } from './actions';
 import MapDownloadHandler from './components/MapDownloadHandler';
@@ -43,7 +50,16 @@ class Builder extends Component {
                     <DistrictsSidebar />
                     <div className="map-container">
                         <MapActions />
-                        <Map />
+                        <Map>
+                            <MapDistrictLayer />
+                            <MapHighlightLayer />
+                            <MapHighlightLayer />
+                            <MapDrawHandler />
+                            <MapLayerHandler />
+                            <MapLabelHandler />
+                            <MapBasemapHandler />
+                            <MapLockLayer />
+                        </Map>
                     </div>
                 </main>
             </div>

--- a/src/components/Context.js
+++ b/src/components/Context.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export const MapContext = React.createContext();
+
+export const withMap = Component => {
+    return function ConnectedComponent(props) {
+        return (
+            <MapContext.Consumer>{map => <Component {...props} map={map} />}</MapContext.Consumer>
+        );
+    };
+};

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -3,18 +3,16 @@ import MapboxGL from 'mapbox-gl';
 import '../css/mapbox-gl.css';
 import ReactResizeDetector from 'react-resize-detector';
 
-import MapDistrictLayer from './MapDistrictLayer';
-import MapHighlightLayer from './MapHighlightLayer';
-import MapLockLayer from './MapLockLayer';
-import MapDrawHandler from './MapDrawHandler';
-import MapLayerHandler from './MapLayerHandler';
-import MapLabelHandler from './MapLabelHandler';
-import MapBasemapHandler from './MapBasemapHandler';
+import { MapContext } from './Context';
 import { mapboxStyle } from '../constants/map-style';
 
 MapboxGL.accessToken = 'pk.eyJ1IjoibGtuYXJmIiwiYSI6IjhjbGg4RUkifQ.-lS6mAkmR3SVh-W4XwQElg';
 
 class Map extends Component {
+  onResize = () => {
+    this.map.resize();
+  };
+
   componentDidMount() {
     this.map = new MapboxGL.Map({
       container: this.mapContainer,
@@ -25,30 +23,20 @@ class Map extends Component {
 
     this.map.doubleClickZoom.disable();
 
-    // TODO: Find a better way to handle this forceUpdate. Right now I am using this to render the component
-    // after the map has loaded. Otherwise, the this.map is not passed into the other components.
     this.map.on('load', () => {
       this.forceUpdate();
     });
   }
 
-  onResize = () => {
-    this.map.resize();
-  };
-
   render() {
     return (
-      <div className="map">
-        <div ref={ref => (this.mapContainer = ref)} />
-        {<ReactResizeDetector handleWidth onResize={this.onResize} />}
-        {this.map && <MapDistrictLayer map={this.map} />}
-        {this.map && <MapHighlightLayer map={this.map} />}
-        {this.map && <MapDrawHandler map={this.map} />}
-        {this.map && <MapLayerHandler map={this.map} />}
-        {this.map && <MapLabelHandler map={this.map} />}
-        {this.map && <MapBasemapHandler map={this.map} />}
-        {this.map && <MapLockLayer map={this.map} />}
-      </div>
+      <MapContext.Provider value={this.map}>
+        <div className="map">
+          <div ref={ref => (this.mapContainer = ref)} />
+          {this.map && this.props.children}
+          <ReactResizeDetector handleWidth onResize={this.onResize} />
+        </div>
+      </MapContext.Provider>
     );
   }
 }

--- a/src/components/MapBasemapHandler.js
+++ b/src/components/MapBasemapHandler.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
 import { addRasterLayer, removeRasterLayer } from '../constants';
+import { withMap } from './Context';
 
 class MapBasemapHandler extends Component {
   render() {
@@ -42,4 +43,4 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps)(MapBasemapHandler);
+export default withMap(connect(mapStateToProps)(MapBasemapHandler));

--- a/src/components/MapDistrictLayer.js
+++ b/src/components/MapDistrictLayer.js
@@ -4,6 +4,7 @@ import geobuf from 'geobuf';
 import Pbf from 'pbf';
 
 import { pointerSelect, acceptChanges, updateGeometry } from '../actions';
+import { withMap } from './Context';
 
 class MapDistrictLayer extends Component {
   onUpdatedDistricts = collection => {
@@ -50,7 +51,9 @@ const mapActionsToProps = {
   onUpdateGeometry: updateGeometry,
 };
 
-export default connect(
-  mapStateToProps,
-  mapActionsToProps
-)(MapDistrictLayer);
+export default withMap(
+  connect(
+    mapStateToProps,
+    mapActionsToProps
+  )(MapDistrictLayer)
+);

--- a/src/components/MapDownloadHandler.js
+++ b/src/components/MapDownloadHandler.js
@@ -16,7 +16,6 @@ class MapDownloadHandler extends Component {
     window.spatialWorker.addEventListener('message', m => {
       switch (m.data.type) {
         case 'DOWNLOAD_GEOJSON':
-          console.log('Download launch');
           FileSaver.saveAs(
             new Blob([JSON.stringify(geobuf.decode(new Pbf(m.data.mergedGeoJSON)))], {
               type: 'text/json;charset=utf-8',

--- a/src/components/MapDrawHandler.js
+++ b/src/components/MapDrawHandler.js
@@ -2,9 +2,11 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
 
-import MapDrawRectangle from './MapDrawRectangle';
-import { pointerSelect, rectangleStart } from '../actions';
 import DrawRectangle from '../util/mapbox-gl-draw-rectangle-mode';
+import MapDrawRectangle from './MapDrawRectangle';
+import { drawStyle } from '../constants/map-style';
+import { pointerSelect, rectangleStart } from '../actions';
+import { withMap } from './Context';
 
 class MapDrawHandler extends Component {
   componentWillMount() {
@@ -14,30 +16,7 @@ class MapDrawHandler extends Component {
       modes: this.modes,
       boxSelect: false,
       displayControlsDefault: false,
-      styles: [
-        {
-          id: 'gl-draw-polygon-stroke-active',
-          type: 'line',
-          filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'Polygon']],
-          layout: {
-            'line-cap': 'round',
-            'line-join': 'round',
-          },
-          paint: {
-            'line-color': '#444',
-            'line-width': 1,
-          },
-        },
-        {
-          id: 'gl-draw-polygon-fill-active',
-          type: 'fill',
-          filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'Polygon']],
-          paint: {
-            'fill-color': '#444',
-            'fill-opacity': 0.4,
-          },
-        },
-      ],
+      styles: drawStyle,
     });
   }
   render() {
@@ -62,7 +41,7 @@ class MapDrawHandler extends Component {
     }
     return (
       <div className="map-draw-handler">
-        <MapDrawRectangle map={this.props.map} draw={this.draw} />
+        <MapDrawRectangle draw={this.draw} />
       </div>
     );
   }
@@ -79,7 +58,9 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapActionsToProps
-)(MapDrawHandler);
+export default withMap(
+  connect(
+    mapStateToProps,
+    mapActionsToProps
+  )(MapDrawHandler)
+);

--- a/src/components/MapDrawRectangle.js
+++ b/src/components/MapDrawRectangle.js
@@ -4,6 +4,7 @@ import debounce from 'lodash/debounce';
 import { bbox } from '@turf/turf';
 
 import { activateResults, selectResults } from '../actions';
+import { withMap } from './Context';
 
 class MapDrawHandler extends Component {
   componentWillMount() {
@@ -91,7 +92,9 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapActionsToProps
-)(MapDrawHandler);
+export default withMap(
+  connect(
+    mapStateToProps,
+    mapActionsToProps
+  )(MapDrawHandler)
+);

--- a/src/components/MapHighlightLayer.js
+++ b/src/components/MapHighlightLayer.js
@@ -3,6 +3,8 @@ import { connect } from 'react-redux';
 import geobuf from 'geobuf';
 import Pbf from 'pbf';
 
+import { withMap } from './Context';
+
 class MapHighlightLayer extends Component {
   componentWillMount() {
     window.spatialWorker.addEventListener('message', m => {
@@ -39,4 +41,4 @@ const mapStateToProps = (state, props) => {
   };
 };
 
-export default connect(mapStateToProps)(MapHighlightLayer);
+export default withMap(connect(mapStateToProps)(MapHighlightLayer));

--- a/src/components/MapLabelHandler.js
+++ b/src/components/MapLabelHandler.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import { withMap } from './Context';
+
 class MapLabelHandler extends Component {
   render() {
     const { mapLabels, selectionLevel, map } = this.props;
@@ -50,4 +52,4 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps)(MapLabelHandler);
+export default withMap(connect(mapStateToProps)(MapLabelHandler));

--- a/src/components/MapLayerHandler.js
+++ b/src/components/MapLayerHandler.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import { withMap } from './Context';
+
 class MapLayerHandler extends Component {
   render() {
     if (this.props.selectionLevel === 'county') {
@@ -19,4 +21,4 @@ const mapStateToProps = state => {
   };
 };
 
-export default connect(mapStateToProps)(MapLayerHandler);
+export default withMap(connect(mapStateToProps)(MapLayerHandler));

--- a/src/components/MapLockLayer.js
+++ b/src/components/MapLockLayer.js
@@ -2,18 +2,19 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { generateLockFilter } from '../util/map';
 
-class MapHighlightLayer extends Component {
-	render() {
-		this.props.map.setFilter('districts-lock', generateLockFilter(this.props.lockedIds));
+import { withMap } from './Context';
 
-		return <div className="map-lock-layer" />;
-	}
+class MapHighlightLayer extends Component {
+    render() {
+        this.props.map.setFilter('districts-lock', generateLockFilter(this.props.lockedIds));
+        return <div className="map-lock-layer" />;
+    }
 }
 
 const mapStateToProps = (state, props) => {
-	return {
-		lockedIds: state.historyState.present.lockedIds,
-	};
+    return {
+        lockedIds: state.historyState.present.lockedIds,
+    };
 };
 
-export default connect(mapStateToProps)(MapHighlightLayer);
+export default withMap(connect(mapStateToProps)(MapHighlightLayer));

--- a/src/components/MapOptions.js
+++ b/src/components/MapOptions.js
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import { changeOptionDrawMode } from '../actions';
 
 class MapActions extends Component {
-  componentDidMount() {}
   renderDrawButtons() {
     const drawModes = ['Pointer', 'Rectangle', 'Line'];
     return drawModes.map((mode, index) => {

--- a/src/constants/map-style.js
+++ b/src/constants/map-style.js
@@ -83,34 +83,6 @@ export const mapboxStyle = {
         'line-width': ['interpolate', ['linear'], ['zoom'], 6, 1.5, 12, 5],
       },
     },
-    // {
-    //   id: 'geounit-circles',
-    //   type: 'circle',
-    //   source: 'blockgroups',
-    //   'source-layer': 'geounitlabels',
-    //   layout: {
-    //     visibility: 'none',
-    //   },
-    //   paint: {
-    //     'circle-color': '#03034f',
-    //     'circle-opacity': ['interpolate', ['linear'], ['zoom'], 7, 0.1, 12, 0.6, 22, 0.6],
-    //     'circle-radius': 0,
-    //   },
-    // },
-    // {
-    //   id: 'county-circles',
-    //   type: 'circle',
-    //   source: 'blockgroups',
-    //   'source-layer': 'countylabels',
-    //   layout: {
-    //     visibility: 'none',
-    //   },
-    //   paint: {
-    //     'circle-color': '#03034f',
-    //     'circle-opacity': ['interpolate', ['linear'], ['zoom'], 7, 0.1, 12, 0.6, 22, 0.6],
-    //     'circle-radius': 0,
-    //   },
-    // },
     {
       id: 'blockgroups-outline',
       type: 'line',
@@ -351,3 +323,28 @@ export const mapboxStyle = {
   sprite: window.location.origin + window.location.pathname + '/sprites/sprite',
   glyphs: window.location.origin + window.location.pathname + '/data/fonts/{fontstack}/{range}.pbf',
 };
+
+export const drawStyle = [
+  {
+    id: 'gl-draw-polygon-stroke-active',
+    type: 'line',
+    filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'Polygon']],
+    layout: {
+      'line-cap': 'round',
+      'line-join': 'round',
+    },
+    paint: {
+      'line-color': '#444',
+      'line-width': 1,
+    },
+  },
+  {
+    id: 'gl-draw-polygon-fill-active',
+    type: 'fill',
+    filter: ['all', ['==', 'active', 'true'], ['==', '$type', 'Polygon']],
+    paint: {
+      'fill-color': '#444',
+      'fill-opacity': 0.4,
+    },
+  },
+];

--- a/src/index.js
+++ b/src/index.js
@@ -23,13 +23,7 @@ const persistConfig = {
 
 const persistedReducer = persistReducer(persistConfig, reducers);
 
-let store = createStore(
-	persistedReducer,
-	compose(
-		applyMiddleware(thunk)
-		// window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-	)
-);
+let store = createStore(persistedReducer, compose(applyMiddleware(thunk)));
 let persistor = persistStore(store);
 
 const routing = (


### PR DESCRIPTION
Use Context.Provider and Context.Consumer to pass Mapbox GL object to child components, without passing it as a prop on each component.