### PR TITLE
Use empty GeoJSON for setData when no selected geounits

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -54,7 +54,6 @@ export const generateSpatialIndex = geoJSON => ({ type: GENERATE_SPATIAL_INDEX, 
 export const generateCountyIndex = geoJSON => ({ type: GENERATE_COUNTY_INDEX, payload: geoJSON });
 
 export const pointerSelect = e => (dispatch, getState) => {
-	console.log(e.features[0].properties);
 	const id = e.features[0].properties.id;
 	const countyfp = e.features[0].properties.countyfp;
 	const { historyState, selectionLevel } = getState();

--- a/src/components/MapHighlightLayer.js
+++ b/src/components/MapHighlightLayer.js
@@ -11,7 +11,13 @@ class MapHighlightLayer extends Component {
       switch (m.data.type) {
         case 'HIGHLIGHT':
           this.geo = geobuf.decode(new Pbf(m.data.results));
-          this.props.map.getSource('highlight').setData(this.geo);
+          if (typeof this.geo.coordinates !== 'undefined') {
+            this.props.map.getSource('highlight').setData(this.geo);
+          } else {
+            this.props.map
+              .getSource('highlight')
+              .setData({ type: 'Feature', properties: { title: 'empty' }, geometry: null });
+          }
           break;
         default:
           break;


### PR DESCRIPTION
We were getting an error on the Netlify deployed site when the highlight layer was set with no data. By passing it an empty GeoJSON, we no longer receive this error. Surprisingly, that error never appeared on local development.